### PR TITLE
Fix: Build Failed - because favicons's url unmatched

### DIFF
--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -12,25 +12,25 @@
 <link rel="shortcut icon" href="{{ icon_url }}/favicon.ico" type="image/x-icon">
 <link rel="icon" href="{{ icon_url }}/favicon.ico" type="image/x-icon">
 
-<link rel="apple-touch-icon" href="{{ icon_url }}/apple-icon.png">
-<link rel="apple-touch-icon" href="{{ icon_url }}/apple-icon-precomposed.png">
-<link rel="apple-touch-icon" sizes="57x57" href="{{ icon_url }}/apple-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="{{ icon_url }}/apple-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="{{ icon_url }}/apple-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="{{ icon_url }}/apple-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="{{ icon_url }}/apple-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="{{ icon_url }}/apple-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="{{ icon_url }}/apple-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="{{ icon_url }}/apple-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="{{ icon_url }}/apple-icon-180x180.png">
+<link rel="apple-touch-icon" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="60x60" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="72x72" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="76x76" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="114x114" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="120x120" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="144x144" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="152x152" href="{{ icon_url }}/favicon.ico">
+<link rel="apple-touch-icon" sizes="180x180" href="{{ icon_url }}/favicon.ico">
 
-<link rel="icon" type="image/png" sizes="192x192"  href="{{ icon_url }}/android-icon-192x192.png">
-<link rel="icon" type="image/png" sizes="32x32" href="{{ icon_url }}/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="96x96" href="{{ icon_url }}/favicon-96x96.png">
-<link rel="icon" type="image/png" sizes="16x16" href="{{ icon_url }}/favicon-16x16.png">
+<link rel="icon" type="image/png" sizes="192x192"  href="{{ icon_url }}/favicon.ico">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ icon_url }}/favicon.ico">
+<link rel="icon" type="image/png" sizes="96x96" href="{{ icon_url }}/favicon.ico">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ icon_url }}/favicon.ico">
 
 <link rel="manifest" href="{{ icon_url }}/manifest.json">
 <meta name='msapplication-config' content='{{ icon_url }}/browserconfig.xml'>
 <meta name="msapplication-TileColor" content="#ffffff">
-<meta name="msapplication-TileImage" content="{{ icon_url }}/ms-icon-144x144.png">
+<meta name="msapplication-TileImage" content="{{ icon_url }}/favicon.ico">
 <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
## Description

favicon.ico 를 바라미 이미지로 변경하는 과정에서, 
apple  ~ 접두사의 favicon.ico를 삭제하였고, 
빌드된 link에서 해당 favicon이 url 이 맞지 않아 build failed가 났음. 

## Type of change
 
- [x] Bug fix (non-breaking change which fixes an issue) 

## How has this been tested
 

- [x] I have run `bash ./tools/test.sh --build` (at the root of the project) locally and passed
- [x] I have tested this feature in the browser
 